### PR TITLE
[UC-25] Add payload to user events

### DIFF
--- a/src/EventSubscriber/CustomerProfileUpdatedSubscriberInterface.php
+++ b/src/EventSubscriber/CustomerProfileUpdatedSubscriberInterface.php
@@ -23,6 +23,7 @@ interface CustomerProfileUpdatedSubscriberInterface
     public const ROUTE_TO_EVENT_MAP = [
         'sylius_customer_profile' => 'customer_profile_update',
         'sylius_admin_customer_update' => 'admin_customer_update',
+        'sylius_shop_account_profile_update' => 'shop_customer_update',
         'sylius_shop_register' => 'customer_registration',
         'sylius_shop_checkout_address' => 'customer_order_address_provided',
     ];

--- a/src/Updater/CustomerWithKeyUpdater.php
+++ b/src/Updater/CustomerWithKeyUpdater.php
@@ -133,11 +133,12 @@ class CustomerWithKeyUpdater extends CustomerWithoutKeyUpdater implements Custom
         ;
 
         $id = $customerFoundByEmailId ?? $userFromUserKey['id'];
+        $payload = $this->buildPayload($email, $customer, $address);
 
         $user = $this->userApi->updateUser(
             $apiAwareResource,
             $id,
-            $this->buildPayload($email, $customer, $address),
+            $payload,
         );
 
         if (is_array($customerFoundByEmail) &&
@@ -147,7 +148,7 @@ class CustomerWithKeyUpdater extends CustomerWithoutKeyUpdater implements Custom
             $this->userApi->mergeUsers($apiAwareResource, $customerFoundByEmail['id'], [$userFromUserKey['id']]);
         }
 
-        $this->sendEvent($apiAwareResource, $email, $eventName);
+        $this->sendEvent($apiAwareResource, $email, $eventName, $payload);
 
         return $user;
     }

--- a/src/Updater/CustomerWithoutKeyUpdater.php
+++ b/src/Updater/CustomerWithoutKeyUpdater.php
@@ -63,7 +63,7 @@ class CustomerWithoutKeyUpdater implements CustomerWithoutKeyUpdaterInterface
         if (false === is_array($user) || false === array_key_exists('id', $user)) {
             throw new \RuntimeException('User was not created or updated.');
         }
-        $this->sendEvent($userApiAwareResource, $user['email'], $eventName);
+        $this->sendEvent($userApiAwareResource, $user['email'], $eventName, $payload);
 
         return $user;
     }
@@ -76,13 +76,14 @@ class CustomerWithoutKeyUpdater implements CustomerWithoutKeyUpdaterInterface
         return $this->customerPayloadBuilder->build($email, $customer, $address);
     }
 
-    protected function sendEvent(UserComApiAwareInterface $resource, string $userCustomId, string $event): void
+    protected function sendEvent(UserComApiAwareInterface $resource, string $userCustomId, string $event, ?array $payload = null): void
     {
         $this->userApi->createEventForUser(
             $resource,
             $userCustomId,
             [
                 'name' => $event,
+                'data' => $payload,
             ],
         );
     }


### PR DESCRIPTION
- Added data to user event. Previously, only the name of the event was sent.
- Added missing event name (shop_customer_update). 