### PR TITLE
[UC-25] Encode query parameter value in UserApi

### DIFF
--- a/doc/functionalities.md
+++ b/doc/functionalities.md
@@ -22,9 +22,8 @@ The **BitBagSyliusUserComPlugin** integrates **User.com** with Sylius-based stor
 ### 4. Event-Driven System
 - Each customer interaction generates an **event**, which is stored and sent to **User.com** for automation and reporting.
 
-### 5. Product Persistence & Feed Generation
+### 5. Product Persistence
 - **Persists products** within the system for accurate data reporting.
-- Generates a **product feed** that can be used for marketing and analytics purposes.
 
 ### 6. Tag Manager Script Injection
 - Allows users to **inject custom scripts** via **Tag Manager**.

--- a/src/Api/UserApi.php
+++ b/src/Api/UserApi.php
@@ -28,7 +28,7 @@ final class UserApi extends AbstractClient implements UserApiInterface
         $url = $this->getApiEndpointUrl(
             $resource,
             self::FIND_USER_ENDPOINT,
-            sprintf('?%s=%s', $field, $value),
+            sprintf('?%s=%s', $field, rawurlencode($value)),
         );
 
         return $this->request(


### PR DESCRIPTION
Resolves a problem that occurred when querying the User.com database for users with special characters in their email addresses.