### PR TITLE
Update installation guide 2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,10 +78,6 @@ jobs:
                 run: php -v | head -n 1 | awk '{ print $2 }' > .php-version
 
             -
-                name: Install certificates
-                run: symfony server:ca:install
-
-            -
                 name: Run Chrome Headless
                 run: google-chrome-stable --enable-automation --disable-background-networking --no-default-browser-check --no-first-run --disable-popup-blocking --disable-default-apps --allow-insecure-localhost --disable-translate --disable-extensions --no-sandbox --enable-features=Metal --headless --remote-debugging-port=9222 --window-size=2880,1800 --proxy-server='direct://' --proxy-bypass-list='*' http://127.0.0.1 > /dev/null 2>&1 &
 

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -13,7 +13,7 @@ default:
 
         Behat\MinkExtension:
             files_path: "%paths.base%/vendor/sylius/sylius/src/Sylius/Behat/Resources/fixtures/"
-            base_url: "https://127.0.0.1:8080/"
+            base_url: "http://127.0.0.1:8080/"
             default_session: symfony
             javascript_session: chrome
             sessions:

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -11,8 +11,15 @@
         USER_COM_COOKIE_DOMAIN=""
         MESSENGER_USER_COM_ASYNCHRONOUS_DSN=""
     ```
-   - You can find the `USER_COM_FRONTEND_API_KEY` in the User.Com integration guide for `Google Tag Manager (Settings->Setup & Integrations)`. 
-   - `USER_COM_COOKIE_DOMAIN` is optional, if not set, cookies will be set for the current domain.
+    - You can find the `USER_COM_FRONTEND_API_KEY` in the User.Com integration guide for `Google Tag Manager (Settings->Setup & Integrations)`.
+    - `USER_COM_ENCRYPTION_KEY` and `USER_COM_ENCRYPTION_IV` are required for cookie encryption.
+- You can generate the encryption key and IV using the following command:
+    ```bash
+      php -r '$key = bin2hex(random_bytes(16)); echo "USER_COM_ENCRYPTION_KEY=\"" . $key . "\"\n"; $iv = bin2hex(random_bytes(8)); echo "USER_COM_ENCRYPTION_IV=\"" . $iv . "\"\n";'
+    ```
+    - `MESSENGER_USER_COM_ASYNCHRONOUS_DSN` is the DSN for the messenger transport that will handle asynchronous messages. You can use different transports like `doctrine://default`, `amqp://guest:guest@localhost:5672/%2f/messages`, etc.
+
+    - `USER_COM_COOKIE_DOMAIN` is optional, if not set, cookies will be set for the current domain.
 
 
 3. Add plugin dependencies to `config/bundles.php` file. Make sure that none of the bundles are duplicated.

--- a/ecs.php
+++ b/ecs.php
@@ -18,4 +18,3 @@ return static function (ECSConfig $ecsConfig): void {
         VisibilityRequiredFixer::class => ['*Spec.php'],
     ]);
 };
-


### PR DESCRIPTION
- Remove unused certificate installation step from build workflow.
- Extend `installation.md` with encryption key/IV generation details and transport DSN examples.
- Adjust Behat configuration to use `http` instead of `https` base URL.